### PR TITLE
fix datePicker always setting one day before the selected

### DIFF
--- a/app/src/main/java/com/umutcansahin/todoapp/ui/add_to_do/AddFragment.kt
+++ b/app/src/main/java/com/umutcansahin/todoapp/ui/add_to_do/AddFragment.kt
@@ -95,8 +95,15 @@ class AddFragment : Fragment(R.layout.fragment_add) {
                     .setSelection(selectedDate.time)
                     .build()
             datePicker.addOnPositiveButtonClickListener { timestamp ->
-                selectedDate = Date(timestamp)
-                dateButton.text = selectedDate.toFormat(Constants.CURRENT_DATE_FORMAT)
+                //set and define the calendar instance to local timezone. It prevents Calendar sets one day before the selected.
+                val selectedUtc = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+                selectedUtc.timeInMillis = timestamp
+                val selectedLocal = Calendar.getInstance()
+                selectedLocal.clear()
+                selectedLocal.set(selectedUtc.get(Calendar.YEAR), selectedUtc.get(Calendar.MONTH), selectedUtc.get(Calendar.DATE))
+
+                selectedDate = selectedLocal.time
+                dateButton.text = selectedLocal.time.toFormat(Constants.CURRENT_DATE_FORMAT)
             }
             datePicker.show(parentFragmentManager, Constants.TAG_DATE_PICKER);
         }


### PR DESCRIPTION
Based on issue discussed on github repo from material components, the selected date from datePicker now is solved.

 https://github.com/material-components/material-components-android/issues/882#issuecomment-1111374962